### PR TITLE
Enhancement: Split Projects Component into two smaller components.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
-  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <link rel="icon" href="https://s3.us-east-2.amazonaws.com/dseskey.com/images/professional-portfolio/Dan+Seskey-2.jpeg" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="Web site created using create-react-app" />

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import React, {useState} from 'react';
 import { Container, Row} from 'react-bootstrap';
 import Header from './components/Header';
 import About from './components/About';
-import Project from './components/Project';
+import Portfolio from './components/Portfolio';
 import Contact from './components/Contact';
 import Resume from './components/Resume';
 import Footer from './components/Footer';
@@ -18,7 +18,7 @@ function App() {
       <Header setActivePage={setActivePage} activePage={activePage}/>
       <Row id='sections-container'>
         {normalizePageNames(activePage) === 'about' && <About/> }
-        {normalizePageNames(activePage) === 'portfolio' && <Project/> }
+        {normalizePageNames(activePage) === 'portfolio' && <Portfolio/> }
         {normalizePageNames(activePage) === 'contact' &&  <Contact/> }
         {normalizePageNames(activePage) === 'resume' &&  <Resume/> }
       </Row>

--- a/src/components/Portfolio/__tests__/__snapshots__/index.test.js.snap
+++ b/src/components/Portfolio/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Project component matches snapshot DOM node structure 1`] = `
+<DocumentFragment>
+  <div
+    class="pagesParentContainer container-fluid"
+    data-testid="portfolio-container"
+    id="portfolio-container"
+  >
+    <div
+      class="pageHeader row"
+    >
+      <h2
+        data-testid="portfolio-section-header"
+      >
+        My Projects
+      </h2>
+    </div>
+    <div
+      class="row"
+      data-testid="projects-card-row"
+      id="projects-card-row"
+    >
+      <div
+        class="col-md-4"
+        data-testid="Travelers Mobile-col"
+      >
+        <div
+          class="card"
+          data-projectname="Travelers Mobile"
+          data-testid="Travelers Mobile-card"
+          style="background-image: url(https://s3.us-east-2.amazonaws.com/dseskey.com/images/professional-portfolio/trvMobileApp.jpeg);"
+        />
+      </div>
+      <div
+        class="col-md-4"
+        data-testid="Noggle Boggle Trivia and Quiz Generator-col"
+      >
+        <div
+          class="card"
+          data-projectname="Noggle Boggle Trivia and Quiz Generator"
+          data-testid="Noggle Boggle Trivia and Quiz Generator-card"
+          style="background-image: url(https://s3.us-east-2.amazonaws.com/dseskey.com/images/professional-portfolio/IMG_1168.jpeg);"
+        />
+      </div>
+      <div
+        class="col-md-4"
+        data-testid="Single Plant Irrigation System (SPIS)-col"
+      >
+        <div
+          class="card"
+          data-projectname="Single Plant Irrigation System (SPIS)"
+          data-testid="Single Plant Irrigation System (SPIS)-card"
+          style="background-image: url(https://s3.us-east-2.amazonaws.com/dseskey.com/images/professional-portfolio/spis.jpg);"
+        />
+      </div>
+      <div
+        class="col-md-4"
+        data-testid="Photography Portfolio-col"
+      >
+        <div
+          class="card"
+          data-projectname="Photography Portfolio"
+          data-testid="Photography Portfolio-card"
+          style="background-image: url(https://s3.us-east-2.amazonaws.com/dseskey.com/images/professional-portfolio/photo-port.jpg);"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/Portfolio/__tests__/index.test.js
+++ b/src/components/Portfolio/__tests__/index.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import {render, cleanup} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import Portfolio from '..'
+
+afterEach(cleanup);
+
+
+describe("Project component", () =>{
+    it('renders', () => {
+        render(<Portfolio/>);
+    });
+    it('matches snapshot DOM node structure', () => {
+        const {asFragment} = render(<Portfolio/>);
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it('has a section container rendered with a portfolio-container ID and the required class of pagesParentContainer', () => {
+       const {getByTestId} = render(<Portfolio/>);
+       expect(getByTestId('portfolio-container')).toHaveClass('pagesParentContainer');
+       expect(getByTestId('portfolio-container')).toHaveAttribute('id', 'portfolio-container');
+
+    });
+    
+    it('has a card for the Travelers Mobile application', () => {
+        const {getByTestId} = render(<Portfolio/>);
+        expect(getByTestId('Travelers Mobile-card')).toHaveClass('card');
+     });
+
+     it('has a project-cards-row with 4 projects (children nodes that represent cards)', () => {
+        const {getByTestId} = render(<Portfolio/>);
+        expect(getByTestId('projects-card-row')).toHaveClass('row');
+        expect(getByTestId('projects-card-row').childElementCount).toEqual(4);
+
+     });
+
+});
+

--- a/src/components/Portfolio/index.js
+++ b/src/components/Portfolio/index.js
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import { Container, Row, Col, Card } from 'react-bootstrap';
+import projectJson from '../../assets/json/projects.json';
+import Project from '../Project';
+function Portfolio() {
+
+    return (
+        <Container fluid data-testid='portfolio-container' id='portfolio-container' className='pagesParentContainer'>
+            <Row className="pageHeader">
+                <h2 data-testid='portfolio-section-header'>My Projects</h2>
+            </Row>
+            <Row data-testid='projects-card-row' id='projects-card-row'>
+                {projectJson.projects.map((project) => {
+                    return (
+                        <Project key={`${project.title}-project`} project={project} />
+                    )
+                })}
+            </Row>
+
+        </Container >
+    )
+}
+
+export default Portfolio;

--- a/src/components/Project/__tests__/__snapshots__/index.test.js.snap
+++ b/src/components/Project/__tests__/__snapshots__/index.test.js.snap
@@ -3,69 +3,15 @@
 exports[`Project component matches snapshot DOM node structure 1`] = `
 <DocumentFragment>
   <div
-    class="pagesParentContainer container-fluid"
-    data-testid="project-container"
-    id="project-container"
+    class="col-md-4"
+    data-testid="Travelers Mobile-col"
   >
     <div
-      class="pageHeader row"
-    >
-      <h2
-        data-testid="project-section-header"
-      >
-        My Projects
-      </h2>
-    </div>
-    <div
-      class="row"
-      data-testid="projects-card-row"
-      id="projects-card-row"
-    >
-      <div
-        class="col-md-4"
-        data-testid="Travelers Mobile-col"
-      >
-        <div
-          class="card"
-          data-projectname="Travelers Mobile"
-          data-testid="Travelers Mobile-card"
-          style="background-image: url(https://s3.us-east-2.amazonaws.com/dseskey.com/images/professional-portfolio/trvMobileApp.jpeg);"
-        />
-      </div>
-      <div
-        class="col-md-4"
-        data-testid="Noggle Boggle Trivia and Quiz Generator-col"
-      >
-        <div
-          class="card"
-          data-projectname="Noggle Boggle Trivia and Quiz Generator"
-          data-testid="Noggle Boggle Trivia and Quiz Generator-card"
-          style="background-image: url(https://s3.us-east-2.amazonaws.com/dseskey.com/images/professional-portfolio/IMG_1168.jpeg);"
-        />
-      </div>
-      <div
-        class="col-md-4"
-        data-testid="Single Plant Irrigation System (SPIS)-col"
-      >
-        <div
-          class="card"
-          data-projectname="Single Plant Irrigation System (SPIS)"
-          data-testid="Single Plant Irrigation System (SPIS)-card"
-          style="background-image: url(https://s3.us-east-2.amazonaws.com/dseskey.com/images/professional-portfolio/spis.jpg);"
-        />
-      </div>
-      <div
-        class="col-md-4"
-        data-testid="Photography Portfolio-col"
-      >
-        <div
-          class="card"
-          data-projectname="Photography Portfolio"
-          data-testid="Photography Portfolio-card"
-          style="background-image: url(https://s3.us-east-2.amazonaws.com/dseskey.com/images/professional-portfolio/photo-port.jpg);"
-        />
-      </div>
-    </div>
+      class="card"
+      data-projectname="Travelers Mobile"
+      data-testid="Travelers Mobile-card"
+      style="background-image: url(https://s3.us-east-2.amazonaws.com/dseskey.com/images/professional-portfolio/trvMobileApp.jpeg);"
+    />
   </div>
 </DocumentFragment>
 `;

--- a/src/components/Project/__tests__/index.test.js
+++ b/src/components/Project/__tests__/index.test.js
@@ -5,33 +5,43 @@ import Project from '..'
 
 afterEach(cleanup);
 
+const project = {
+    title: "Travelers Mobile",
+    description: "The Travelers mobile application is a React Native based application leveraging AWS and on-prem infrastructure.",
+    urls: [
+        {
+            type: "github",
+            url:"http://www.github.com"
+        },
+        {
+            type: "itunes",
+            url: "https://apps.apple.com/us/app/travelers-mobile/id354604876#?platform=iphone"
+        }
+    ],
+    imageSRC:"https://s3.us-east-2.amazonaws.com/dseskey.com/images/professional-portfolio/trvMobileApp.jpeg"
+}
 
 describe("Project component", () =>{
     it('renders', () => {
-        render(<Project/>);
+        render(<Project project={project}/>);
     });
     it('matches snapshot DOM node structure', () => {
-        const {asFragment} = render(<Project/>);
+        const {asFragment} = render(<Project project={project}/>);
         expect(asFragment()).toMatchSnapshot();
     });
 
-    it('has a section container rendered with a project-container ID and the required class of pagesParentContainer', () => {
-       const {getByTestId} = render(<Project/>);
-       expect(getByTestId('project-container')).toHaveClass('pagesParentContainer');
-       expect(getByTestId('project-container')).toHaveAttribute('id', 'project-container');
+    it('has a Col container with an ID of the Travelers Mobile-col and class col-md-4', () => {
+       const {getByTestId} = render(<Project project={project}/>);
+       expect(getByTestId('Travelers Mobile-col')).toHaveClass('col-md-4');
 
     });
-    
-    it('has a card for the Travelers Mobile application', () => {
-        const {getByTestId} = render(<Project/>);
+
+    it('has a Card with a project name of Travelers mobile, class of card, and a style with a background using the S3 URL', () => {
+        const {getByTestId} = render(<Project project={project}/>);
         expect(getByTestId('Travelers Mobile-card')).toHaveClass('card');
-     });
-
-     it('has a project-cards-row with 4 projects (children nodes that represent cards)', () => {
-        const {getByTestId} = render(<Project/>);
-        expect(getByTestId('projects-card-row')).toHaveClass('row');
-        expect(getByTestId('projects-card-row').childElementCount).toEqual(4);
-
+        expect(getByTestId('Travelers Mobile-card')).toHaveAttribute('data-projectname','Travelers Mobile');
+        expect(getByTestId('Travelers Mobile-card')).toHaveStyle('background-image: url(https://s3.us-east-2.amazonaws.com/dseskey.com/images/professional-portfolio/trvMobileApp.jpeg)')
+ 
      });
 
      /*TODO: Add a test to validate hover render*/

--- a/src/components/Project/index.js
+++ b/src/components/Project/index.js
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import { Container, Row, Col, Card } from 'react-bootstrap';
-import projectJson from '../../assets/json/projects.json';
-import {SocialIcon} from 'react-social-icons';
+import {Row, Col, Card } from 'react-bootstrap';
+import { SocialIcon } from 'react-social-icons';
 
-function Project() {
+function Project({project}) {
     const [hoveredCard, setHoveredCard] = useState('');
     const [iconHover, setIconHover] = useState('');
+
     /*--Functions to generate each part of the project card. Although this can be done straight in the main return, this makes it easier to work with and triage--*/
     function generateCardTitle(project) {
         const { title } = project;
@@ -20,19 +20,19 @@ function Project() {
         )
     }
 
-    function handleIconMouseEvents(event, socialIconName){
-        if(event.type==='mouseover'){
+    function handleIconMouseEvents(event, socialIconName) {
+        if (event.type === 'mouseover') {
             setIconHover(socialIconName);
-        }else{
+        } else {
             setIconHover('');
         }
     }
 
-    function generateURLs(urlObj, title){
-        const {type, url} = urlObj
+    function generateURLs(urlObj, title) {
+        const { type, url } = urlObj
         return (
             <Col key={`${title}-${type}-urlCol`} >
-                <SocialIcon key={`${title}-${type}-social-icon`}  onMouseOut={(event)=>handleIconMouseEvents(event)} onMouseOver={(event) => {handleIconMouseEvents(event,`${title}-${type}`)}} fgColor={iconHover===`${title}-${type}` ? '#007bff' : ''} network={type} url={url} bgColor={iconHover===`${title}-${type}` ? '#FFF' : '#DCE0D9'} alt={type} />
+                <SocialIcon key={`${title}-${type}-social-icon`} onMouseOut={(event) => handleIconMouseEvents(event)} onMouseOver={(event) => { handleIconMouseEvents(event, `${title}-${type}`) }} fgColor={iconHover === `${title}-${type}` ? '#007bff' : ''} network={type} url={url} bgColor={iconHover === `${title}-${type}` ? '#FFF' : '#DCE0D9'} alt={type} />
             </Col>
         )
     }
@@ -45,53 +45,43 @@ function Project() {
         }
     }
     return (
-        <Container fluid data-testid='project-container' id='project-container' className='pagesParentContainer'>
-            <Row className="pageHeader">
-                <h2 data-testid='project-section-header'>My Projects</h2>
-            </Row>
-            <Row data-testid='projects-card-row' id='projects-card-row'>
-                {projectJson.projects.map((project) => {
-                    return (
-                        <Col
-                            data-testid={`${project.title}-col`} key={project.title + '-col'}
-                            md={4}>
-                            <Card
-                            data-projectname={`${project.title}`}
-                                onMouseEnter={(event) => handleCardHoverFocus(event)}
-                                onMouseLeave={(event) => handleCardHoverFocus(event)}
-                                style={{backgroundImage: `url(${project.imageSRC})`}}
-                                data-testid={`${project.title}-card`} key={project.title + '-card'}>
-                                {hoveredCard === `${project.title}-card` &&
-                                    <div className='projectHoverContainer'>
-                                        <Card.Body key={project.title + '-card-body-content'}>
-                                            {project.title &&
-                                                generateCardTitle(project)
-                                            }
-                                            {project.description &&
-                                                generateCardDescription(project)
-                                            }
-                                            <Row id='project-urls-container'>
-                                                {
-                                                    project.urls &&
-                                                    project.urls.map((urlObj) => {
-                                                        return generateURLs(urlObj,project.title)
-                                                    })
-                                                }
-                                            </Row>
+        <Col
+            data-testid={`${project.title}-col`} key={project.title + '-col'}
+            md={4}>
+            <Card
+                data-projectname={`${project.title}`}
+                onMouseEnter={(event) => handleCardHoverFocus(event)}
+                onMouseLeave={(event) => handleCardHoverFocus(event)}
+                style={{ backgroundImage: `url(${project.imageSRC})` }}
+                data-testid={`${project.title}-card`} key={project.title + '-card'}>
+                 
+                {hoveredCard === `${project.title}-card` &&
+                    <div className='projectHoverContainer'>
+                        <Card.Body key={project.title + '-card-body-content'}>
+                            {project.title &&
+                                generateCardTitle(project)
+                            }
+                            {project.description &&
+                                generateCardDescription(project)
+                            }
+                            <Row id='project-urls-container'>
+                                {
+                                    project.urls &&
+                                    project.urls.map((urlObj) => {
+                                        return generateURLs(urlObj, project.title)
+                                    })
+                                }
+                            </Row>
 
-                                        </Card.Body>
+                        </Card.Body>
 
-                                    </div>
-                                } 
-                            </Card>
-                            
-                        </Col>
+                    </div>
+                }
+            </Card>
 
-                    )
-                })}
-            </Row>
+        </Col>
 
-        </Container >
+    
     )
 }
 


### PR DESCRIPTION
Split the Project Component into two components:

1) Portfolio - the parent page for the portfolio section.
2) Projects - the reusable project card generator used by the portfolio page.

Applicable tests are written.

This pull requests resolves [issue 28](https://github.com/dseskey/professional-portfolio-ui/issues/28).